### PR TITLE
兼容一些组件库对按需加载的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ export default (): UserConfigExport => {
 
   // Replace component file loading path. Only effective when building
   libDirectory?: string
+
+  // Custom component file conversion
+  resolveComponent: (name: string) => string;
 }
 
 // LibraryNameChangeCase

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ export default (): UserConfigExport => {
   // If the style file is not .css suffix. Need to turn on this option
   esModule?: boolean;
 
+  // Replace component file loading path. Only effective when building
+  libDirectory?: string
 }
 
 // LibraryNameChangeCase

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Lib {
    */
   libraryName: string;
   esModule?: boolean;
+  libDirectory?: string,
   resolveStyle: (name: string) => string;
   libraryNameChangeCase?: LibraryNameChangeCase;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Lib {
   libraryName: string;
   esModule?: boolean;
   libDirectory?: string,
+  resolveComponent?: (name: string) => string,
   resolveStyle: (name: string) => string;
   libraryNameChangeCase?: LibraryNameChangeCase;
 }


### PR DESCRIPTION
### 原因
一些组件由于历史原因对 `esm` 支持的不是很完美，在构建时仍然需对组件的引入要做类似 `babel-import` 的处理。

### 改动点
当参数中有 `libDirectory` 时，会在构建时对组件引用路径做更改。