### PR TITLE
refactor: adjust the processing of transformComponentImportName

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface Lib {
   /**
    * Custom imported component style conversion
    */
-  resolveStyle: (name: string) => string;
+  resolveStyle?: (name: string) => string;
 
   /**
    * There may be some component libraries that are not very standardized.

--- a/tests/transformComponent.spec.ts
+++ b/tests/transformComponent.spec.ts
@@ -1,0 +1,58 @@
+import vitePluginComponentImport from '../src';
+import { init } from 'es-module-lexer';
+import { Lib } from '../src/types';
+
+const createVitePluginComponentImport = (libs: Lib[]) =>
+  (vitePluginComponentImport({
+    libs,
+  }) as unknown) as {
+    configResolved: (opts: { isProduction: boolean; build: Record<string, any> }) => void;
+    transform: (
+      code: string,
+      id: string
+    ) => {
+      map: string | null;
+      code: string;
+    };
+  };
+
+test('use transformComponent', async () => {
+  await init;
+
+  const { transform } = createVitePluginComponentImport([
+    {
+      libraryName: 'lib',
+      transformComponentImportName: (name: string) => `{ ${name} }`,
+    },
+  ]);
+
+  const res = await transform(`import { libName } from 'lib'`, 'lib_path.ts');
+
+  expect(res).toStrictEqual({ map: null, code: "import { libName } from 'lib'\n" });
+});
+
+test('do not use transformComponent', async () => {
+  await init;
+
+  const { transform, configResolved } = createVitePluginComponentImport([
+    {
+      libraryName: 'lib',
+      resolveComponent: (name) => name,
+    },
+  ]);
+
+  configResolved({ isProduction: true, build: {} });
+
+  const res = await transform(
+    `import { libName } from 'lib';
+import { libName2 } from 'lib2';`,
+    'lib_path.ts'
+  );
+
+  expect(res).toStrictEqual({
+    map: null,
+    code: `
+import libName from 'lib-name';\n
+import { libName2 } from 'lib2';`,
+  });
+});


### PR DESCRIPTION
调整因为 https://github.com/anncwb/vite-plugin-style-import/issues/12 而增加的 `transformComponentImportName` 的处理

按照现有的处理，会导致 https://github.com/anncwb/vite-plugin-style-import/blob/d56d8c92ff272527379449c10771ba768baf4fdd/src/index.ts#L101-L103 

无法正确删除已经被转化的 `import name`，而是叠加在原有的 `import name` 下，使得

https://github.com/anncwb/vite-plugin-style-import/blob/d56d8c92ff272527379449c10771ba768baf4fdd/src/index.ts#L105-L108 抛出 `[import name] has already been declared` 异常