### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,10 +165,13 @@ async function removeAlreadyName(
   importComponents.filter((comp) => {
     const name = getChangeCaseFileName(comp, libraryNameChangeCase);
     const importStr = resolveStyle?.(name);
-    const cssFile = resolveNodeModules(root, importStr!);
-
-    if (fs.existsSync(cssFile)) {
-      hasCssList.push(comp);
+    if (importStr) {
+      const cssFile = resolveNodeModules(root, importStr!);
+      if (fs.existsSync(cssFile)) {
+        hasCssList.push(comp);
+      } else {
+        unCssList.push(comp);
+      }
     } else {
       unCssList.push(comp);
     }
@@ -322,6 +325,7 @@ function getLib(libraryName: string, libs: Lib[], external?: ExternalOption) {
       });
     }
   }
+  
   return libList.find((item) => item.libraryName === libraryName);
 }
 


### PR DESCRIPTION
fixed：if `importStr` is `undefined`，`resolveNodeModules` will break eg：
``` shell
[vite:style-import] The "path" argument must be of type string. Received undefined
file: filepath
error during build:
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:124:11)
    at Object.join (path.js:1148:7)
    at resolveNodeModules (/Users/yuistack/Documents/bilibili/laputa/node_modules/vite-plugin-style-import/dist/index.js:21:58)
    at /Users/yuistack/Documents/bilibili/laputa/node_modules/vite-plugin-style-import/dist/index.js:158:21
    at Array.filter (<anonymous>)
    at removeAlreadyName (/Users/yuistack/Documents/bilibili/laputa/node_modules/vite-plugin-style-import/dist/index.js:155:20)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Object.transform (/Users/yuistack/Documents/bilibili/laputa/node_modules/vite-plugin-style-import/dist/index.js:120:44)
    at async ModuleLoader.addModuleSource (/Users/yuistack/Documents/bilibili/laputa/node_modules/rollup/dist/shared/rollup.js:19706:30)
    at async ModuleLoader.fetchModule (/Users/yuistack/Documents/bilibili/laputa/node_modules/rollup/dist/shared/rollup.js:19762:9)
```