### PR TITLE
fix: path normalization

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { normalizePath } from 'vite'
 import fs from 'fs'
 
 export function resolveNodeModules(libName: string, ...dir: string[]) {
-  const modulePath = require.resolve(libName)
+  const modulePath = normalizePath(require.resolve(libName))
   const lastIndex = modulePath.indexOf(libName)
 
   return normalizePath(path.resolve(modulePath.substring(0, lastIndex), ...dir))


### PR DESCRIPTION
fix: 修复windows上解析路径分隔符为（ \ ），导致解析路径错误。