### PR TITLE
Support for Node ESM mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.2.1",
   "description": "A plug-in that imports component library styles on demand",
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "types": "dist/index.d.ts",
   "license": "MIT",
   "author": "Vben",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { init, parse, ImportSpecifier } from 'es-module-lexer'
 import MagicString from 'magic-string'
 import path from 'path'
 import fs from 'fs'
-import { debug as Debug } from 'debug'
+import Debug from 'debug'
 import { fileExists, isPnp, isRegExp, resolveNodeModules, resolvePnp } from './utils'
 
 const debug = Debug('vite-plugin-style-import')


### PR DESCRIPTION
CommonJS version of the package was used when called from ESM package (that was using "type": module"). That caused duplicate wrapping of exports of `vite-plugin-style-import`, making runtime exports start with `default.default`.