### PR TITLE
fix: added support for running from an es module

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import { normalizePath } from 'vite'
 import fs from 'fs'
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
 
 export function resolveNodeModules(libName: string, ...dir: string[]) {
   const modulePath = normalizePath(require.resolve(libName))


### PR DESCRIPTION
Fixes `[vite:style-import] __require.resolve is not a function` error when this plugin is run from a Node ESM package, which is what everyone should upgrade to anyways.

