### PR TITLE
fix: 2.0.0_Cannot find module 'consola'

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",
     "change-case": "^4.1.2",
-    "console": "^0.7.2",
+    "consola": "^2.15.3",
     "es-module-lexer": "^0.9.3",
     "fs-extra": "^10.0.0",
     "magic-string": "^0.25.7",


### PR DESCRIPTION
不在外部进行
```
pnpm install
```

cd 到 /packages/playground/basic目录：

```
yarn 
yarn dev
```
即可重现