### PR TITLE
fix: fix the error that the 2.0 version prompts that `consola` cannot be found

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",
     "change-case": "^4.1.2",
-    "console": "^0.7.2",
+    "consola": "^2.15.3",
     "es-module-lexer": "^0.9.3",
     "fs-extra": "^10.0.0",
     "magic-string": "^0.25.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/node': ^17.0.13
       change-case: ^4.1.2
-      console: ^0.7.2
+      consola: ^2.15.3
       es-module-lexer: ^0.9.3
       fs-extra: ^10.0.0
       magic-string: ^0.25.7
@@ -63,7 +63,7 @@ importers:
     dependencies:
       '@rollup/pluginutils': 4.1.2
       change-case: 4.1.2
-      console: 0.7.2
+      consola: 2.15.3
       es-module-lexer: 0.9.3
       fs-extra: 10.0.0
       magic-string: 0.25.7
@@ -2213,11 +2213,6 @@ packages:
       {
         integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==,
       }
-    dev: true
-
-  /console/0.7.2:
-    resolution: { integrity: sha1-+aQzEkkpFZG3v5v/qOIFNW8gqfA= }
-    dev: false
 
   /constant-case/3.0.4:
     resolution:


### PR DESCRIPTION

<strong>Error in v2.0</strong>

<img width="1136" alt="error" src="https://user-images.githubusercontent.com/16821989/167278300-95e8ed5b-97df-46c5-a82e-f6b478e0b523.png">

fix the error that the 2.0 version prompts that consola cannot be found