### PR TITLE
fix: change default exclude config for monorepo support

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,7 @@ consola.wrapConsole()
 export function createStyleImportPlugin(options: VitePluginOptions): Plugin {
   const {
     include = ['**/*.vue', '**/*.ts', '**/*.js', '**/*.tsx', '**/*.jsx'],
-    exclude = 'node_modules/**',
+    exclude = '**/node_modules/**',
     resolves = [],
   } = options
 


### PR DESCRIPTION
When using monorepo, the package may be promoted to the node_modules of the root directory, so the exclude configuration will not take effect, causing some packages to fail to find css files, such as antd-pro。

<img width="622" alt="image" src="https://user-images.githubusercontent.com/8850879/222374685-27a80bc8-334f-4070-b512-f8d28728fc67.png">
<img width="674" alt="image" src="https://user-images.githubusercontent.com/8850879/222374741-eca601ad-aa78-4c18-a092-0d59e0ab80ae.png">
